### PR TITLE
Update docs to point users towards current implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Update 2023
 
 This package is still maintained, but the code has been upstreamed into `functorch.dim` in the PyTorch repository.
 
-On modern versions of PyTorch it can imported with `from functorch.dim import dims`.
+On modern versions of PyTorch, it can be imported with `from functorch.dim import dims`.
 
 Direct Installation from this Repository (Outdated)
 ---------------

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ def embedding_bag(input: torch.Tensor, embedding_weights: torch.Tensor):
 Installation
 ============
 
+Update 2023
+---------------
+
+This package is still maintained, but the code has been upstreamed into `functorch.dim` in the PyTorch repository.
+
+On modern versions of PyTorch it can imported with `from functorch.dim import dims`.
+
+Direct Installation from this Repository (Outdated)
+---------------
 
 _torchdim is a preview release so that we can collect feedback on the API. It may have bugs, and there are known places where performance can be improved._
 


### PR DESCRIPTION
Hey!

I accidentally spent a bit too long in this repository before realising the code was upstreamed into `functorch.dim`.

Here's a quick README.md change so others don't make the same mistake. Any modifications welcome.

